### PR TITLE
Fixed crash when compiled for iOS app runs on Mac

### DIFF
--- a/Runtime/Platforms/Mobile/Dependencies/UnityCoreHaptics/Plugins/iOS/Source/UnityCoreHaptics.swift
+++ b/Runtime/Platforms/Mobile/Dependencies/UnityCoreHaptics/Plugins/iOS/Source/UnityCoreHaptics.swift
@@ -176,11 +176,12 @@ import UnityFramework_CoreHapticsPrivate
 
     @objc public static func PlayHapticsFromJSON(str: String) {
         Debug(log: "Playing haptic from JSON")
-        StartEngine();
         if (!SupportsHaptics)
         {
             return;
         }
+
+        StartEngine();
         
         do
         {
@@ -234,7 +235,10 @@ import UnityFramework_CoreHapticsPrivate
     
     @objc public static func CancelHaptics()
     {
-        Engine.stop();
+        if(_engine != nil)
+        {
+            _engine.stop();
+        }
         _engineNeedsStart = true;
     }
     


### PR DESCRIPTION
To reproduce - buid app with SDK for iOS. Run it on Mac, application crashes.
On Mac haptics not supported and _engine is always nil.